### PR TITLE
Updated Appsync configuration instructions for subscriptions

### DIFF
--- a/instructions/content/30_part1_queries/33_listCompanies.md
+++ b/instructions/content/30_part1_queries/33_listCompanies.md
@@ -47,11 +47,10 @@ Amplify.configure({
         graphql_headers: async () => ({
             Authorization: (await Auth.currentSession()).getIdToken().getJwtToken()
         }),
-        graphql_endpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
-    },
-    aws_appsync_region: process.env.REACT_APP_DEFAULT_REGION,
-    aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
-    aws_appsync_graphqlEndpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
+        aws_appsync_region: process.env.REACT_APP_DEFAULT_REGION,
+        aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
+        aws_appsync_graphqlEndpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
+    }
 });
 ```
 

--- a/instructions/content/30_part1_queries/33_listCompanies.md
+++ b/instructions/content/30_part1_queries/33_listCompanies.md
@@ -47,10 +47,11 @@ Amplify.configure({
         graphql_headers: async () => ({
             Authorization: (await Auth.currentSession()).getIdToken().getJwtToken()
         }),
-        aws_appsync_region: process.env.REACT_APP_DEFAULT_REGION,
-        aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
-        aws_appsync_graphqlEndpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
-    }
+        graphql_endpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
+    },
+    aws_appsync_region: process.env.REACT_APP_DEFAULT_REGION,
+    aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
+    aws_appsync_graphqlEndpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
 });
 ```
 

--- a/instructions/content/50_part3_subscriptions/52_subscription_instructions.md
+++ b/instructions/content/50_part3_subscriptions/52_subscription_instructions.md
@@ -10,6 +10,34 @@ The goal of this section is to change how the Detail page updates its its displa
 
 ### Client Changes
 
+-   When using subscriptions, we need to move our appsync configuration to the root of the configuration object.  To do this, update the amplify configure code in `StockTable.tsx`
+
+```tsx
+Amplify.configure({
+    Auth: {
+        region: process.env.REACT_APP_DEFAULT_REGION,
+        userPoolId: process.env.REACT_APP_COGNITO_POOL_ID,
+        userPoolWebClientId: process.env.REACT_APP_COGNITO_POOL_CLIENT_ID
+    },
+    API: {
+        endpoints: [
+            {
+                name: API_NAME,
+                endpoint: process.env.REACT_APP_API_ENDPOINT,
+                region: process.env.REACT_APP_DEFAULT_REGION
+            }
+        ],
+        graphql_headers: async () => ({
+            Authorization: (await Auth.currentSession()).getIdToken().getJwtToken()
+        }),
+        graphql_endpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
+    },
+    aws_appsync_region: process.env.REACT_APP_DEFAULT_REGION,
+    aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
+    aws_appsync_graphqlEndpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
+});
+```
+
 -   In Cloud 9 create a new folder under '/src/web/src/graphql/subscriptions.js' We will store our queries in here. Add this as an import to StockDetails.tsx
 
 ```tsx

--- a/src/web/solution/part3/StockDetail.tsx
+++ b/src/web/solution/part3/StockDetail.tsx
@@ -9,10 +9,10 @@ import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, Label } from "re
 import * as queries from "./graphql/queries.js";
 import * as mutations from "./graphql/mutations.js";
 
-// STEP 0 - BEGIN
+// STEP 1 - BEGIN
 // Include the AppSync subscriptions
 import * as subscriptions from "./graphql/subscriptions.js";
-// STEP 0 - END
+// STEP 1 - END
 
 import MediaCard from "./MediaCard";
 import StockActions from "./StockActions";
@@ -46,14 +46,14 @@ interface State {
     simulate: boolean;
     simulation: number;
 
-    // STEP 1 - BEGIN
+    // STEP 2 - BEGIN
     // Add a new state property
     stockSubscription: {};
-    // STEP 1 - END
+    // STEP 2 - END
 }
 
-interface StyleProps extends WithStyles<typeof styles> {}
-interface RouterProps extends RouteComponentProps<{}> {}
+interface StyleProps extends WithStyles<typeof styles> { }
+interface RouterProps extends RouteComponentProps<{}> { }
 type Props = StyleProps &
     RouterProps & {
         selectedCompany: number;
@@ -70,12 +70,12 @@ class StockDetail extends Component<Props, State> {
         simulate: false,
         simulation: 0,
 
-        // STEP 2 - BEGIN
+        // STEP 3 - BEGIN
         // Implement the new state property
         stockSubscription: {
-            unsubscribe: () => {}
+            unsubscribe: () => { }
         }
-        // STEP 2 - END
+        // STEP 3 - END
     };
 
     constructor(props: Props) {
@@ -89,22 +89,22 @@ class StockDetail extends Component<Props, State> {
         this.retrieveHistogram = this.retrieveHistogram.bind(this);
         this.onSimulate = this.onSimulate.bind(this);
 
-        // STEP 2 - BEGIN
+        // STEP 3 - BEGIN
         // Bind the function that will receive the subscription updates
         this.onStock = this.onStock.bind(this);
-        // STEP 2 - END
+        // STEP 3 - END
 
-        // STEP 3 - BEGIN
+        // STEP 4 - BEGIN
         // Initiate the AppSync subscription
         this.state.stockSubscription = API.graphql(graphqlOperation(subscriptions.SubscribeToStock))
             //@ts-ignore
             .subscribe({
                 next: this.onStock
             });
-        // STEP 3 - END
+        // STEP 4 - END
     }
 
-    // STEP 4 - BEGIN
+    // STEP 5 - BEGIN
     // Implement the function that will receive the subscription updates
     async onStock({ value }: any) {
         console.log("On Stock change: ", value.data);
@@ -117,7 +117,7 @@ class StockDetail extends Component<Props, State> {
         });
         await this.retrieveHistogram();
     }
-    // STEP 4 - END
+    // STEP 5 - END
 
     async componentDidMount() {
         //@ts-ignore
@@ -144,10 +144,10 @@ class StockDetail extends Component<Props, State> {
     }
 
     componentWillUnmount() {
-        // STEP 5 - BEGIN
+        // STEP 6 - BEGIN
         // Clean up the subscription connection when the component is no longer needed
         this.state.stockSubscription.unsubscribe();
-        // STEP 5 - END
+        // STEP 6 - END
     }
 
     async onAction() {
@@ -208,7 +208,7 @@ class StockDetail extends Component<Props, State> {
                         <MediaCard
                             media={this.renderChart()}
                             value={this.state.company.stock_value}
-                            onAutoRefresh={() => {}}
+                            onAutoRefresh={() => { }}
                         />
                     </Grid>
                     <Grid item xs={6}>

--- a/src/web/solution/part3/StockTable.tsx
+++ b/src/web/solution/part3/StockTable.tsx
@@ -16,19 +16,32 @@ import * as queries from "./graphql/queries.js";
 
 const API_NAME = "companies";
 
+// STEP 0 - BEGIN
+// Modify Amplify configure
 Amplify.configure({
     Auth: {
         region: process.env.REACT_APP_DEFAULT_REGION,
         userPoolId: process.env.REACT_APP_COGNITO_POOL_ID,
         userPoolWebClientId: process.env.REACT_APP_COGNITO_POOL_CLIENT_ID
     },
-    graphql_headers: async () => ({
-        Authorization: (await Auth.currentSession()).getIdToken().getJwtToken()
-    }),
+    API: {
+        endpoints: [
+            {
+                name: API_NAME,
+                endpoint: process.env.REACT_APP_API_ENDPOINT,
+                region: process.env.REACT_APP_DEFAULT_REGION
+            }
+        ],
+        graphql_headers: async () => ({
+            Authorization: (await Auth.currentSession()).getIdToken().getJwtToken()
+        }),
+        graphql_endpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
+    },
     aws_appsync_region: process.env.REACT_APP_DEFAULT_REGION,
     aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
     aws_appsync_graphqlEndpoint: process.env.REACT_APP_APPSYNC_ENDPOINT
 });
+// STEP 0 - END
 
 const styles = (theme: any) =>
     createStyles({
@@ -56,7 +69,7 @@ type Company = {
     stock_value: number;
 };
 
-interface Props extends WithStyles<typeof styles> {}
+interface Props extends WithStyles<typeof styles> { }
 
 interface State {
     itemData: Array<Object>;


### PR DESCRIPTION
In the [Amplify Documentation](https://aws-amplify.github.io/docs/js/api#subscriptions) it states that 

> When using AWS AppSync subscriptions, be sure that your AppSync configuration is at the root of the configuration object, instead of being under API

In order for subscriptions to work, I have moved the `aws_appsync_*` configurations outside of API and added `graphql_endpoint` to the `API` object
